### PR TITLE
chore: 添加 pnpm 依赖安装配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .dumi/tmp-production
 .DS_Store
 package-lock.json
+.idea

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+lockfile=false
+resolution-mode=highest


### PR DESCRIPTION
pnpm v8 默认走的是锁依赖 + 最低版本安装策略，不符合我们始终安装最新版本包的理念。

改成不锁依赖 + 安装最高版