### PR TITLE
Revert "chore: 支持 cjs 打包构建"

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'father';
 
 export default defineConfig({
+  // more father config: https://github.com/umijs/father/blob/master/docs/config.md
   esm: { output: 'es' },
-  cjs: { output: 'lib', platform: 'browser' },
 });

--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "description": "🌟 Lightweight Editor UI Framework",
   "license": "MIT",
   "sideEffects": false,
-  "main": "lib/index.js",
+  "main": "es/index.js",
   "module": "es/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "es/index.d.ts",
   "files": [
-    "es",
-    "lib"
+    "es"
   ],
   "scripts": {
     "build": "father build",


### PR DESCRIPTION
This reverts commit c56c238c89e8311a184c222c6a3e8d8347b3737f.

由于 `shiki-es` 是一个纯 esm 包，如果基于 father 打出 cjs 包，会使用 require('shiki-es') 的方式引入，这会促使在 SSR（node 环境）下报错。

```md
Failed to compile.

./node_modules/.pnpm/@ant-design+pro-editor@0.2.1_@emotion+react@11.11.1_@emotion+styled@11.11.0_@types+react@18.2_443pbeikamqhp5cqu7w4qwpyfi/node_modules/@ant-design/pro-editor/lib/Highlight/hooks/useShiki.js
Module not found: ESM packages (shiki-es) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals

https://nextjs.org/docs/messages/module-not-found
```

问过辟起，目前 father4 不会很好地支持纯 esm 转 cjs ，因此后续打包策略应该是打纯 esm 模块。然后在下游消费方中解决构建问题。

在 nextjs 中，可以通过配置 `transpilePackages` 实现 esm 模块转换为 cjs 。

```
/** @type {import('next').NextConfig} */
const nextConfig = {
  // es 模块编译
  transpilePackages: ['@ant-design/pro-editor'],
};

module.exports =nextConfig;
```

相应的缺点则是构建会慢一些。

在 umi 中是默认使用的 esm，而且大部分情况下也不需要 SSR，所以问题不大。如果需要后续需要的话，可以考虑将本模块提交到这里 https://github.com/umijs/es5-imcompatible-versions