### PR TITLE
修正文档构建部署

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   // },
   favicons: ['https://gw.alipayobjects.com/zos/antfincdn/upvrAjAPQX/Logo_Tech%252520UI.svg'],
   // @ts-ignore
-  ssr: isProd ? {} : false,
+  ssr: false,
   hash: true,
   ignoreMomentLocale: true,
   codeSplitting: {

--- a/docs/pro-editor/demos/defaultAssets.tsx
+++ b/docs/pro-editor/demos/defaultAssets.tsx
@@ -2,7 +2,7 @@
  * iframe: 600
  */
 import { demoAssets } from '@/ComponentAsset/demoAssets';
-import { ComponentAsset, ProEditor } from '@/index';
+import { ComponentAsset, ProEditor } from '@ant-design/pro-editor';
 
 export default () => (
   <ProEditor

--- a/docs/pro-editor/demos/empty.tsx
+++ b/docs/pro-editor/demos/empty.tsx
@@ -1,6 +1,6 @@
 /**
  * iframe: 300
  */
-import { ProEditor } from '@/index';
+import { ProEditor } from '@ant-design/pro-editor';
 
 export default () => <ProEditor style={{ height: '100vh' }} />;

--- a/docs/pro-editor/demos/realtimeCollaboration/demo.tsx
+++ b/docs/pro-editor/demos/realtimeCollaboration/demo.tsx
@@ -1,4 +1,4 @@
-import { Awareness } from '@/index';
+import { Awareness } from '@ant-design/pro-editor';
 import { Button, Divider, Input } from 'antd';
 import { memo } from 'react';
 import { WebrtcProvider } from 'y-webrtc';

--- a/docs/pro-editor/demos/realtimeCollaboration/store.ts
+++ b/docs/pro-editor/demos/realtimeCollaboration/store.ts
@@ -1,9 +1,8 @@
+import { yjsMiddleware } from '@ant-design/pro-editor';
 import { Doc } from 'yjs';
 import type { StoreApi } from 'zustand';
 import { create } from 'zustand';
 import { createContext } from 'zustand-utils';
-
-import { yjsMiddleware } from '@/index';
 
 interface Store {
   count: number;


### PR DESCRIPTION
将 组件 lazy 化后引入（ https://github.com/ant-design/pro-editor/pull/36/commits/dfe8bd54a9a3e411ffae3c3537280d2d13a4677e ），会导致文档构建无法正常退出。

- https://github.com/ant-design/pro-editor/actions/runs/5307072977
- https://github.com/ant-design/pro-editor/actions/runs/5306762512

可能和 dumi 的 ssr 逻辑有关，先关闭 ssr 修复一下