### PR TITLE
fix: docs deploy error

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -15,9 +15,6 @@ export default defineConfig({
   ssr: false,
   hash: true,
   ignoreMomentLocale: true,
-  codeSplitting: {
-    jsStrategy: 'granularChunks',
-  },
   themeConfig: {
     hero: {
       'zh-CN': {


### PR DESCRIPTION
1. github pages 使用 Jekyll 构建页面, jekyll 默认忽略 _ 开头的文件和文件夹。
2. granularChunks 代码拆分方式会生成 _ 开头的 chunk 文件

close #43 