### PR TITLE
:bug: fix: 修复crypto.randomUUID 在 http 中无法使用的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lodash.unionby": "^4.8.0",
     "lodash.uniq": "^4.5.0",
     "mockjs": "^1.1.0",
+    "nanoid": "^5.0.1",
     "polished": "^4.2.2",
     "prettier": "^2.8.8",
     "rc-util": "^5.37.0",

--- a/src/SortableList/utils/index.tsx
+++ b/src/SortableList/utils/index.tsx
@@ -1,5 +1,6 @@
 import type { UniqueIdentifier } from '@dnd-kit/core';
 import isEqual from 'lodash.isequal';
+import { nanoid } from 'nanoid';
 import { useEffect, useState } from 'react';
 
 const defaultInitializer = (index: number) => index;
@@ -66,5 +67,5 @@ export const getIndexOfActiveItem = (list: any[], id?: UniqueIdentifier) => {
 };
 
 export const getUUID = (index) => {
-  return process.env.NODE_ENV === 'test' ? `test-${index}` : crypto.randomUUID();
+  return process.env.NODE_ENV === 'test' ? `test-${index}` : nanoid();
 };


### PR DESCRIPTION
使用 nanoid 替代 crypto.randomUUID ，因为 crypto.randomUUID 在 http 中无法使用。