### PR TITLE
:zap: feat: markdown support html render

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-rnd": "^10.4.1",
     "reactflow": "^11.10.1",
     "rehype-katex": "^6.0.3",
+    "rehype-raw": "^6.0.0",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "rxjs": "^7.8.1",

--- a/src/Markdown/demos/data.ts
+++ b/src/Markdown/demos/data.ts
@@ -85,4 +85,21 @@ $$
 $$
 \\int_{a}^{b} f(x) \\, dx
 $$
+
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Custom Html Dom Render</title>
+</head>
+<body>
+<div>Custom Html Dom Render</div>
+<ul>
+    <li>Ant Desgin</li>
+    <li>Ant Desgin Pro</li>
+    <li>Ant Desgin Pro Components</li>
+</ul>
+
+</body>
+</html>
 `;

--- a/src/Markdown/index.tsx
+++ b/src/Markdown/index.tsx
@@ -2,6 +2,7 @@ import { Collapse, Divider, Typography } from 'antd';
 import { CSSProperties, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
+import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
@@ -39,7 +40,7 @@ const Markdown = memo<MarkdownProps>(({ children, className, style, onDoubleClic
       <ReactMarkdown
         className={styles.markdown}
         components={components}
-        rehypePlugins={[rehypeKatex] as PluggableList}
+        rehypePlugins={[rehypeKatex, rehypeRaw] as PluggableList}
         remarkPlugins={[remarkGfm, remarkMath]}
         {...rest}
       >

--- a/tests/__snapshots__/demo.test.tsx.snap
+++ b/tests/__snapshots__/demo.test.tsx.snap
@@ -25849,7 +25849,6 @@ id sem consectetuer libero luctus adipiscing.
 
         <li>
           Parish
-          
 
           <ol>
             
@@ -25861,7 +25860,6 @@ id sem consectetuer libero luctus adipiscing.
 
             <li>
               McHale
-              
 
               <ol>
                 
@@ -25908,7 +25906,6 @@ id sem consectetuer libero luctus adipiscing.
 
         <li>
           Blue
-          
 
           <ul>
             
@@ -25920,7 +25917,6 @@ id sem consectetuer libero luctus adipiscing.
 
             <li>
               Green
-              
 
               <ul>
                 
@@ -25967,6 +25963,21 @@ id sem consectetuer libero luctus adipiscing.
         />
       </p>
       
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
       <table>
         <thead>
@@ -27867,6 +27878,55 @@ id sem consectetuer libero luctus adipiscing.
           </span>
         </span>
       </div>
+      
+
+
+
+      <meta
+        charset="UTF-8"
+      />
+      
+
+      <meta
+        content="width=device-width, initial-scale=1.0"
+        name="viewport"
+      />
+      
+
+      <title>
+        Custom Html Dom Render
+      </title>
+      
+
+
+
+      <div>
+        Custom Html Dom Render
+      </div>
+      
+
+      <ul>
+        
+    
+        <li>
+          Ant Desgin
+        </li>
+        
+    
+        <li>
+          Ant Desgin Pro
+        </li>
+        
+    
+        <li>
+          Ant Desgin Pro Components
+        </li>
+        
+
+      </ul>
+      
+
+
     </div>
   </article>
 </div>


### PR DESCRIPTION
links：https://github.com/ant-design/pro-editor/issues/131
添加 rehype-raw 支持 Markdown 渲染 原生 Html 内容