### PR TITLE
🐛 fix(draggable-panel): 修改展开受控模式的高度塌陷问题 (#127)

### DIFF
--- a/src/DraggablePanel/FixMode.tsx
+++ b/src/DraggablePanel/FixMode.tsx
@@ -190,7 +190,7 @@ const FixMode: FC<FixModePanelProps> = memo<FixModePanelProps>(
           maxHeight: typeof maxHeight === 'number' ? Math.max(maxHeight, 0) : undefined,
           maxWidth: typeof maxWidth === 'number' ? Math.max(maxWidth, 0) : undefined,
           defaultSize,
-          size: size as Size,
+          size: (size || { height: 'auto' }) as Size,
           style,
         }
       : {

--- a/src/DraggablePanel/demos/controlFixed.tsx
+++ b/src/DraggablePanel/demos/controlFixed.tsx
@@ -1,0 +1,29 @@
+/**
+ * compact: false
+ */
+import { DraggablePanel } from '@ant-design/pro-editor';
+import { useState } from 'react';
+
+export default () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div
+      style={{
+        height: 300,
+        display: 'flex',
+        overflow: 'hidden',
+        maxWidth: '100%',
+      }}
+    >
+      <div style={{ flex: 1, padding: 12 }}>Content</div>
+      <DraggablePanel
+        style={{ padding: 12 }}
+        maxWidth={600}
+        isExpand={open}
+        onExpandChange={setOpen}
+      >
+        Right Panel
+      </DraggablePanel>
+    </div>
+  );
+};

--- a/src/DraggablePanel/index.en-US.md
+++ b/src/DraggablePanel/index.en-US.md
@@ -18,6 +18,8 @@ Used for panels that need to be stretched or dragged and moved.
 
 <code src="./demos/top.tsx" title="Fixed Panel at the Top" description="The panel at the top is fixed and can be dragged up and down"></code>
 
+<code src="./demos/controlFixed.tsx" title="Fixed Panel expandable controlled" description="The panel  is fixed and expand can be controlled"></code>
+
 <code src="./demos/float.tsx" compact="true" title="Floating Draggable Panel" description="Set `mode` to `float`"></code>
 
 <code src="./demos/controlFloat.tsx" compact="true" title="Floating Controlled Mode" description="The position of the floating panel is controlled"></code>

--- a/src/DraggablePanel/index.zh-CN.md
+++ b/src/DraggablePanel/index.zh-CN.md
@@ -18,6 +18,8 @@ group: 面板模块
 
 <code src="./demos/top.tsx" title="顶部面板固定" description="顶部面板固定，上下拖动"></code>
 
+<code src="./demos/controlFixed.tsx" title="面板展开受控" description="右侧面板固定，展开状态受控模式"></code>
+
 <code src="./demos/float.tsx" compact="true" title="悬浮可拖拽面板" description="设置 `mode` 为 `float`"></code>
 
 <code src="./demos/controlFloat.tsx" compact="true" title="悬浮受控模式" description="悬浮框位置受控"></code>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

通过将DraggablePanel的size给一个默认值，来恢复宽高的自动伸缩，防止高度塌陷。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
解决的问题：https://github.com/ant-design/pro-editor/issues/127
<!-- Add any other context about the Pull Request here. -->
