### PR TITLE
:bug: fix: 公式无法正确渲染

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "diff": "^5.1.0",
     "fast-deep-equal": "^3.1.3",
     "immer": "^9.0.21",
+    "katex": "^0.16.11",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",

--- a/src/Markdown/index.tsx
+++ b/src/Markdown/index.tsx
@@ -1,11 +1,11 @@
 import { Collapse, Divider, Typography } from 'antd';
+import 'katex/dist/katex.css';
 import { CSSProperties, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { PluggableList } from 'react-markdown/lib/react-markdown';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
-
-import { PluggableList } from 'react-markdown/lib/react-markdown';
 import { withProvider } from '..';
 import { Code } from './CodeBlock';
 import { useStyles } from './style';
@@ -49,7 +49,11 @@ const Markdown = memo<MarkdownProps>(
     };
 
     const rehypePlugins = [rehypeKatex, ...(outRehypePlugins || [])];
-    const remarkPlugins = [[remarkGfm,{singleTilde: false}], remarkMath, ...(outRemarkPlugins || [])];
+    const remarkPlugins = [
+      [remarkGfm, { singleTilde: false }],
+      remarkMath,
+      ...(outRemarkPlugins || []),
+    ];
 
     return (
       <Typography className={className} onDoubleClick={onDoubleClick} style={style}>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

+ 引入katex对应样式，正确渲染markdown内的数学公式

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

+ 在[官网](https://pro-editor.antdigital.dev/components/markdown#markdown-demo-demos)上
katex由于没有引入对应的css样式，无法正确渲染，而项目使用pnpm，阻止了直接引用rehype-katex中的katex
<img width="452" alt="image" src="https://github.com/user-attachments/assets/bea349da-87e6-49fe-b93a-65c1144ee7bb">

+ 修改后
引入katex包，并在markdown中使用对应katex样式，正确渲染
<img width="499" alt="image" src="https://github.com/user-attachments/assets/5af8aede-2b82-42c8-877e-8358700c96a4">

<!-- Add any other context about the Pull Request here. -->
